### PR TITLE
Add apps trigger options

### DIFF
--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -929,7 +929,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
         let appState = app.get_state();
       
         if(this._appConfigs.includes(appId)){            
-            // Block App _activeWorkspacestate signal
+            // Block App state signal
             appSys.block_signal_handler(this._appStateChangedSignalId);
             
             // Allow blank screen

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -982,27 +982,8 @@ class Caffeine extends QuickSettings.SystemIndicator {
             GLib.Source.remove(this._timePrint);
             this._timePrint = null;
         }
-        if (this._appStateChangedSignalId > 0) {
-            this._appSystem.disconnect(this._appStateChangedSignalId);
-            this._appStateChangedSignalId = 0;
-        }      
-        if (this._appDisplayChangedSignalId > 0) {
-            global.display.disconnect(this._appDisplayChangedSignalId);
-            this._appDisplayChangedSignalId = 0;
-        }       
-        if (this._appWorkspaceChangedSignalId > 0) {
-            global.workspace_manager.disconnect(this._appWorkspaceChangedSignalId);
-            this._appWorkspaceChangedSignalId = 0;
-        }
-        if (this._appAddWindowSignalId > 0) {            
-            this._activeWorkspace.disconnect(this._appAddWindowSignalId);
-            this._appAddWindowSignalId = 0;
-        }        
-        if (this._appRemoveWindowSignalId > 0) {
-            this._activeWorkspace.disconnect(this._appRemoveWindowSignalId);
-            this._appRemoveWindowSignalId = 0;
-        } 
-        
+        this._resetAppSignalId();
+
         // Disconnect settings signals
         if (this.inhibitId) {
             this._settings.disconnect(this.inhibitId);

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -862,26 +862,34 @@ class Caffeine extends QuickSettings.SystemIndicator {
             this._activeWorkspace.disconnect(this._appRemoveWindowSignalId);
             this._appRemoveWindowSignalId = 0;
         } 
-        
+
         // Get active workspace
         this._activeWorkspace = global.workspace_manager.get_active_workspace();
         
         // Add signal listener on add/remove windows for the active workspace
         this._appAddWindowSignalId = 
-            this._activeWorkspace.connect('window-added', () => {
-            // Add 100 ms delay to handle window detection
-            setTimeout(this._toggleWorkspace.bind(this), 100);
+            this._activeWorkspace.connect('window-added', (wkspace, window) => {
+            const type = window.get_window_type();
+            // Accept only normal window, ignore all other type (dialog, menu,...)
+            if(type === 0) {
+                // Add 100 ms delay to handle window detection
+                setTimeout(this._toggleWorkspace.bind(this), 100);
+            }
         });
         this._appRemoveWindowSignalId = 
-            this._activeWorkspace.connect('window-removed', () => {
-            // Add 100 ms delay to handle window detection
-            setTimeout(this._toggleWorkspace.bind(this), 100);
+            this._activeWorkspace.connect('window-removed', (wkspace, window) => {
+            const type = window.get_window_type();
+            // Accept only normal window, ignore all other type (dialog, menu,...)
+            if(type === 0) {
+                // Add 100 ms delay to handle window detection
+                setTimeout(this._toggleWorkspace.bind(this), 100);
+            }
         });
 
         // Check and toggle Caffeine
         this._toggleWorkspace();
     }
- 
+
     _appWindowFocusChanged() {
         let winTrack = Shell.WindowTracker.get_default();
         let appId = null;
@@ -906,7 +914,7 @@ class Caffeine extends QuickSettings.SystemIndicator {
     _appStateChanged(appSys, app) {
         let appId = app.get_id();
         let appState = app.get_state();
-        
+      
         if(this._appConfigs.includes(appId)){            
             // Block App state signal
             appSys.block_signal_handler(this._appStateChangedSignalId);

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -354,10 +354,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
             this._resetAppSignalId();
             this._updateAppEventMode();
         });
-        /*this._appsChangedId = this._appSystem.connect(
-            'installed-changed',
-            this._updateAppData.bind(this));
-        */
         this.connect('destroy', () => {
             this.quickSettingsItems.forEach(item => item.destroy());
         });
@@ -957,10 +953,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
             global.window_manager.disconnect(this._windowDestroyedId);
             this._windowDestroyedId = 0;
         }
-        /*if (this._appsChangedId) {
-            this._appSystem.disconnect(this._appsChangedId);
-            this._appsChangedId = 0;
-        }*/
         if (this._timeOut) {
             GLib.Source.remove(this._timeOut);
             this._timeOut = null;

--- a/caffeine@patapon.info/extension.js
+++ b/caffeine@patapon.info/extension.js
@@ -832,11 +832,6 @@ class Caffeine extends QuickSettings.SystemIndicator {
                             global.workspace_manager.connect('workspace-switched', 
                                 this._appWorkspaceChanged.bind(this));
                     }
-                    /*if(this._appStateChangedSignalId === 0){
-                        this._appStateChangedSignalId =
-                            this._appSystem.connect('app-state-changed', 
-                                this._appWorkspaceChanged.bind(this));        
-                    }*/
                     // Check if App is currently on active workspace
                     this._appWorkspaceChanged();
                     break;

--- a/caffeine@patapon.info/preferences/appsPage.js
+++ b/caffeine@patapon.info/preferences/appsPage.js
@@ -25,6 +25,12 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
 const _ = Gettext.gettext;
 
+const AppsModeChoices = {
+    RUNNING: _("running"),
+    FOCUS: _("focus"),
+    WORKSPACE: _("on active workspace"),
+};
+
 var AppsPage = GObject.registerClass(
 class Caffeine_AppsPage extends Adw.PreferencesPage {
     _init(settings, settingsKey) {
@@ -36,8 +42,30 @@ class Caffeine_AppsPage extends Adw.PreferencesPage {
         this._settingsKey= settingsKey;
         this._settings = settings;
         this._listApps=[];
+
+        // Apps behavior group
+        // --------------
+        let appsBehaviorGroup = new Adw.PreferencesGroup({
+            title: _("Trigger mode")
+        });
         
-        // Apps group
+        // Apps behavior select mode
+        let appsTriggerMode = new Gtk.StringList();
+        appsTriggerMode.append(AppsModeChoices.RUNNING);
+        appsTriggerMode.append(AppsModeChoices.FOCUS);
+        appsTriggerMode.append(AppsModeChoices.WORKSPACE);
+        let appsTriggerModeRow = new Adw.ComboRow({
+            title: _("Apps trigger Caffeine when"),
+            subtitle: _("Choose the way apps will trigger Caffeine"),
+            model: appsTriggerMode,
+            selected: this._settings.get_enum(this._settingsKey.TRIGGER_APPS_MODE)
+        });
+
+        // Add elements
+        appsBehaviorGroup.add(appsTriggerModeRow);
+        this.add(appsBehaviorGroup);
+        
+        // Apps list group
         // --------------
         let addAppsButton = new Gtk.Button({
             child: new Adw.ButtonContent({

--- a/caffeine@patapon.info/preferences/appsPage.js
+++ b/caffeine@patapon.info/preferences/appsPage.js
@@ -26,9 +26,9 @@ const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
 const _ = Gettext.gettext;
 
 const AppsModeChoices = {
-    RUNNING: _("running"),
-    FOCUS: _("focus"),
-    WORKSPACE: _("on active workspace"),
+    RUNNING: _("Running"),
+    FOCUS: _("Focus"),
+    WORKSPACE: _("Active workspace"),
 };
 
 var AppsPage = GObject.registerClass(
@@ -55,7 +55,7 @@ class Caffeine_AppsPage extends Adw.PreferencesPage {
         appsTriggerMode.append(AppsModeChoices.FOCUS);
         appsTriggerMode.append(AppsModeChoices.WORKSPACE);
         let appsTriggerModeRow = new Adw.ComboRow({
-            title: _("Apps trigger Caffeine when"),
+            title: _("Apps trigger Caffeine mode"),
             subtitle: _("Choose the way apps will trigger Caffeine"),
             model: appsTriggerMode,
             selected: this._settings.get_enum(this._settingsKey.TRIGGER_APPS_MODE)

--- a/caffeine@patapon.info/preferences/appsPage.js
+++ b/caffeine@patapon.info/preferences/appsPage.js
@@ -84,8 +84,10 @@ class Caffeine_AppsPage extends Adw.PreferencesPage {
         this.add(this.appsGroup);
         
         // Bind signals
-        addAppsButton.connect('clicked', this._onAddApp.bind(this));
-        
+        addAppsButton.connect('clicked', this._onAddApp.bind(this)); 
+        appsTriggerModeRow.connect('notify::selected', (widget) => {
+            this._settings.set_enum(this._settingsKey.TRIGGER_APPS_MODE, widget.selected);
+        });
     }
     
     _refreshApps() {
@@ -223,5 +225,7 @@ const NewAppDialog = GObject.registerClass(
                 appInfo && !apps.some(i => i.startsWith(appInfo.get_id())));
         }
     });
+
+
 
 

--- a/caffeine@patapon.info/prefs.js
+++ b/caffeine@patapon.info/prefs.js
@@ -39,6 +39,7 @@ const SettingsKey = {
     DEFAULT_WIDTH: 'prefs-default-width',
     DEFAULT_HEIGHT: 'prefs-default-height',
     SCREEN_BLANK: 'screen-blank',
+    TRIGGER_APPS_MODE: 'trigger-apps-mode',
     INDICATOR_POSITION: 'indicator-position',
     INDICATOR_INDEX: 'indicator-position-index',
     INDICATOR_POS_MAX: 'indicator-position-max',
@@ -81,5 +82,6 @@ function fillPreferencesWindow(window) {
         window.destroy();
     });
 }
+
 
 

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -22,6 +22,11 @@
         <summary>Application list</summary>
         <description>A list of strings, each containing an application id (desktop file name)</description>
     </key>
+    <key type="b" name="toggle-state">
+        <default>false</default>
+        <summary>Store caffeine toggle state</summary>
+        <description></description>
+    </key>
     <key type="b" name="user-enabled">
         <default>false</default>
         <summary>Store caffeine user state</summary>
@@ -104,6 +109,7 @@
     </key>
   </schema>
 </schemalist>
+
 
 
 

--- a/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
+++ b/caffeine@patapon.info/schemas/org.gnome.shell.extensions.caffeine.gschema.xml
@@ -10,6 +10,11 @@
         <value value="1" nick="always"/>
         <value value="2" nick="never"/>
    </enum>
+   <enum id="org.gnome.shell.extensions.caffeine.app-trigger-mode">
+        <value value="0" nick="on-running"/>
+        <value value="1" nick="on-focus"/>
+        <value value="2" nick="on-active-workspace"/>
+   </enum>
 
   <schema path="/org/gnome/shell/extensions/caffeine/" id="org.gnome.shell.extensions.caffeine">
     <key type="as" name="inhibit-apps">
@@ -67,6 +72,11 @@
         <summary>Allow screen blank</summary>
         <description>Allow turning off screen when Caffeine is enabled.</description>
     </key>
+    <key name="trigger-apps-mode" enum="org.gnome.shell.extensions.caffeine.app-trigger-mode">
+        <default>"on-running"</default>
+        <summary>Trigger App control mode</summary>
+        <description>Set the trigger method for apps.</description>
+    </key>
     <key type="as" name="toggle-shortcut">
         <default><![CDATA[[]]]></default>
         <summary>Toggle shortcut</summary>
@@ -94,6 +104,7 @@
     </key>
   </schema>
 </schemalist>
+
 
 
 


### PR DESCRIPTION
- Add 3 new trigger apps mod:
    - 'Running': apps trigger Caffeine when running.
    - 'Focus': apps trigger Caffeine only when focused.
    - 'Active workspace': apps trigger Caffeine only when they are located on the active workspace.
- Rewrite partly inhibit mechanism to handle multiple requests in a restricted amount of time (needed for multiple apps inhibited with 'active workspace' mod).
- Sync toggle menu button with real time Caffeine state.
- Clean code.